### PR TITLE
Refactor: use a better syntax for retrieving Location header from the prepare_for_authenticate function

### DIFF
--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -133,11 +133,9 @@ def sp_initiated_login(request: HttpRequest) -> HttpResponseRedirect:
             saml_client = get_saml_client(get_assertion_url(request), acs, user_id)
             jwt_token = create_jwt_token(user_id)
             _, info = saml_client.prepare_for_authenticate(sign=False, relay_state=jwt_token)
-            redirect_url = ""
-            for header in info["headers"]:
-                if header[0] == "Location":
-                    redirect_url = header[1]
-                    break
+            redirect_url = dict(info["headers"]).get("Location", "")
+            if not redirect_url:
+                return HttpResponseRedirect(get_reverse([denied, "denied", "django_saml2_auth:denied"]))
             return HttpResponseRedirect(redirect_url)
     else:
         raise SAMLAuthError("Request method is not supported.", extra={


### PR DESCRIPTION
**Description:**
The info["headers"] data structure is a list of tuples containing header key and its value, which can easily be converted to a dictionary and then a simple key lookup will quickly find the "Location" header.

**Changes:**
[refactor] Use dict for getting Location header instead of for-loop
[feat] Redirect invalid Location header to denied page